### PR TITLE
Fix drawing of fixed rectangle

### DIFF
--- a/src/lib/OLED/OLED.cpp
+++ b/src/lib/OLED/OLED.cpp
@@ -209,7 +209,7 @@ void OLED::drawFilledRectangle(uint8_t x,
                                uint8_t width,
                                uint8_t height) {
     for (uint8_t i = 0; i < height; i++) {
-        drawFastHLine(x, y, width);
+        drawFastHLine(x, y+i, width);
     }
 }
 


### PR DESCRIPTION
Draw the whole filled rectangle instead of only the top line