### PR TITLE
Add one argument to constructor to handle upside-down screen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## 1. Description
 This is a C++ library for raspberry pi pico.
 
-It's based on offical pi pico examples. If you are intersted in it, you can find it here [Pico Examples OLED I2C](https://github.com/raspberrypi/pico-examples/tree/master/i2c/oled_i2c).
+It's based on offical pi pico examples. If you are interested in it, you can find it here [Pico Examples OLED I2C](https://github.com/raspberrypi/pico-examples/tree/master/i2c/oled_i2c).
 ![Pi Pico and OLED](images/Pi%20Pico%20and%20OLED.jpg)
 
 ## 2.Function Lists
@@ -46,19 +46,21 @@ The main programme is at OLEDDISPLAY.cpp file.
 
 You may need to change CMakeLists.txt file according to your enviroment.
 
-### 3.2 Declear an oled object
+### 3.2 Declare an oled object
 
 ```cpp
 #include "OLED.h"
 
 int main(){
-    // SCL, SDA, Width, Height, Frequency, I2C Port
-    OLED oled(5, 4, 128, 64, 400000, i2c0);
+    // SCL, SDA, Width, Height, Frequency, Upside-down, I2C Port
+    OLED oled(5, 4, 128, 64, 400000, false, i2c0);
     return 0;
 }
 ```
 
 Note that, in this library I use default I2C0 and default I2C pins which is `GPIO4-SDA` and `GPIO5-SCL`, you can change it using other default i2c pins. Here I use SSD1306 recommanded I2C max speed, **400KHz**.
+
+The 6th parameter to the constructor call is whether the screen whould be upside-down or not. If true, the screen will be reversed.
 
 ### 3.3 Draw some shapes
 
@@ -66,8 +68,8 @@ Note that, in this library I use default I2C0 and default I2C pins which is `GPI
 #include "OLED.h"
 
 int main(){
-    // SCL, SDA, Width, Height, Frequency, I2C Port
-    OLED oled(5, 4, 128, 64, 400000, i2c0);
+    // SCL, SDA, Width, Height, Frequency, Upside-down, I2C Port
+    OLED oled(5, 4, 128, 64, 400000, false, i2c0);
     // Rectangle
     oled.drawRectangle(0, 0, 50, 30);
     oled.drawFilledRectangle(5, 5, 40, 20);
@@ -89,8 +91,8 @@ Note that you must call `show()` function after you finish draw shapes. So as pr
 #include "Cherry_Cream_Soda_Regular_16.h"
 
 int main(){
-    // SCL, SDA, Width, Height, Frequency, I2C Port
-    OLED oled(5, 4, 128, 64, 400000, i2c0);
+    // SCL, SDA, Width, Height, Frequency, Upside-down, I2C Port
+    OLED oled(5, 4, 128, 64, 400000, false, i2c0);
     //String 1 "Hello", use defaule font
     uint8_t string1[] = "Hello";
     oled.print(0, 38, string1);

--- a/src/lib/OLED/OLED.cpp
+++ b/src/lib/OLED/OLED.cpp
@@ -33,13 +33,23 @@ void OLED::init() {
     write_cmd(0x00);
     // Start line from 0
     write_cmd(SET_DISP_START_LINE);
+    write_cmd(0x00);
     // Set seg-map
-    write_cmd(SET_SEG_REMAP | 0x01);
+    if (reversed) {
+        write_cmd(SET_SEG_REMAP);
+    } else {
+        write_cmd(SET_SEG_REMAP | 0x01);
+    }
     // Set oled height
     write_cmd(SET_MUX_RATIO);
     write_cmd(HEIGHT - 1);
     // Set COM output scan directionscan from bottom up, COM[0] to COM[N-1]
-    write_cmd(SET_COM_OUT_DIR | 0x08);
+    if (reversed) {
+        write_cmd(SET_COM_OUT_DIR_REVERSE);
+    } else {
+        write_cmd(SET_COM_OUT_DIR);
+    }
+    
     // Set display offset
     write_cmd(SET_DISP_OFFSET);
     write_cmd(0x00);
@@ -79,6 +89,7 @@ OLED::OLED(uint8_t scl,
            uint8_t width,
            uint8_t height,
            uint32_t freq,
+           bool rev,
            i2c_inst_t* i2c) {
     // OLED object init
 
@@ -87,6 +98,7 @@ OLED::OLED(uint8_t scl,
     OLED_SDA_PIN = sda, OLED_SCL_PIN = scl;
     FREQUENCY = freq, I2C_PORT = i2c;
     myFont = &Dialog_bold_16;
+    reversed = rev;
 
     clear();
     // i2c init
@@ -128,6 +140,7 @@ void OLED::show() {
     write_cmd(SET_PAGE_ADDR);
     write_cmd(0);
     write_cmd(PAGES - 1);
+
     for (uint16_t i = 0; i < BUFFERSIZE; i++) {
         write_data(BUFFER[i]);
     }

--- a/src/lib/OLED/OLED.h
+++ b/src/lib/OLED/OLED.h
@@ -16,7 +16,7 @@
 #define SET_DISP_START_LINE 0x40
 #define SET_SEG_REMAP 0xA0
 #define SET_MUX_RATIO 0xA8
-#define SET_COM_OUT_DIR 0xC0
+#define SET_COM_OUT_DIR 0xC8
 #define SET_DISP_OFFSET 0xD3
 #define SET_COM_PIN_CFG 0xDA
 #define SET_DISP_CLK_DIV 0xD5
@@ -25,6 +25,7 @@
 #define SET_CHARGE_PUMP 0x8D
 #define SET_SCROLL 0x2E
 #define SET_HOR_SCROLL 0x26
+#define SET_COM_OUT_DIR_REVERSE 0xC0
 
 struct GFXglyph {
     uint16_t bitmapOffset;  ///< Pointer into GFXfont->bitmap
@@ -56,6 +57,7 @@ class OLED {
     uint8_t HEIGHT;
     uint8_t PAGES;
     uint16_t BUFFERSIZE;
+    bool reversed;
     uint8_t BUFFER[1024];
     const GFXfont* myFont;
 
@@ -72,6 +74,7 @@ class OLED {
          uint8_t width,
          uint8_t height,
          uint32_t freq,
+         bool reversed,
          i2c_inst_t* i2c);
     ~OLED();
     void show();


### PR DESCRIPTION
This commit allows for having the screen upside down by passing an additional argument to the constructor. I did this for my own use, so another way to do it may be better. Just two commands from the initialization routine have to be changed for the screen to be upside down.